### PR TITLE
Use `contain` to declare classes to allow relationships

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -2,14 +2,11 @@
 #
 # Manage /etc/crypto-policies/config, and run update-crypto-policies if it changes
 #
-# @example
-#   include crypto_policies::config
-class crypto_policies::config (
-  Stdlib::Absolutepath $config_file = '/etc/crypto-policies/config',
-  Crypto_policies::Policy $policy = 'DEFAULT',
-) {
-  file { $config_file:
-    content => "# This file is managed by puppet\n${policy}\n",
+# @api private
+class crypto_policies::config {
+
+  file { $crypto_policies::config_file:
+    content => "# This file is managed by puppet\n${crypto_policies::policy}\n",
     owner   => 'root',
     group   => 'root',
     mode    => '0644',
@@ -19,6 +16,6 @@ class crypto_policies::config (
     user        => 'root',
     path        => ['/usr/bin'],
     refreshonly => true,
-    subscribe   => File[$config_file],
+    subscribe   => File[$crypto_policies::config_file],
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -26,13 +26,11 @@ class crypto_policies (
   Stdlib::Absolutepath $config_file = '/etc/crypto-policies/config',
   Array[String] $packages = ['crypto-policies'],
 ) {
-  class { 'crypto_policies::install':
-    packages => $packages,
-    notify   => Class['crypto_policies::config'],
-  }
 
-  class { 'crypto_policies::config':
-    config_file => $config_file,
-    policy      => $policy,
-  }
+  contain crypto_policies::install
+  contain crypto_policies::config
+
+  Class['crypto_policies::install']
+  ~> Class['crypto_policies::config']
+
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -3,8 +3,6 @@
 # Ensure the required packages for crypto policies are installed
 #
 # @api private
-class crypto_policies::install (
-  Array[String] $packages = ['crypto-policies'],
-) {
-  stdlib::ensure_packages($packages)
+class crypto_policies::install {
+  stdlib::ensure_packages($crypto_policies::packages)
 }


### PR DESCRIPTION
This allows to create relationships between external classes and this class.

Given the following snippet to create and configure a new subpolicy:
```puppet
class {'crypto_policies':
  policy => 'DEFAULT:OPENSSL-SHA1',
}

file { '/etc/crypto-policies/policies/modules/OPENSSL-SHA1.pmod':
  ensure  => file,
  owner   => 'root',
  group   => 'root',
  mode    => '0644',
  content => "hash@openssl = SHA1+\n",
  notify  => Class['crypto_policies'],
}
```

It won't be executed in the right order despite the `notify`. `crypto_policies::config` is executed before and fails, as the subpolicy file does not yet exist:
```
Notice: /Stage[main]/Crypto_policies::Config/File[/etc/crypto-policies/config]/content:
Notice: /Stage[main]/Crypto_policies::Config/File[/etc/crypto-policies/config]/content: content changed '{sha256}024afa580cbbb917b9025477ee299b1bdeb6dd7019c47304dd054d9d1fd85bb7' to '{sha256}42368cb1e9aca1bef5cb03f59ebd70399b8ff1f0d131ba7d513dd2789091cea3'
Info: /Stage[main]/Crypto_policies::Config/File[/etc/crypto-policies/config]: Scheduling refresh of Exec[update-crypto-policies]
Notice: /Stage[main]/Crypto_policies::Config/Exec[update-crypto-policies]/returns: Unknown policy `OPENSSL-SHA1`: file `OPENSSL-SHA1.pmod` not found in (., policies/modules, /etc/crypto-policies/policies/modules, /usr/share/crypto-policies/policies/modules)
Error: /Stage[main]/Crypto_policies::Config/Exec[update-crypto-policies]: Failed to call refresh: 'update-crypto-policies' returned 1 instead of one of [0]
Error: /Stage[main]/Crypto_policies::Config/Exec[update-crypto-policies]: 'update-crypto-policies' returned 1 instead of one of [0]
Info: Class[Crypto_policies::Config]: Unscheduling all events on Class[Crypto_policies::Config]
Notice: /Stage[main]/Main/File[/etc/crypto-policies/policies/modules/OPENSSL-SHA1.pmod]/ensure: defined content as '{sha256}59aa8744c5d112fc8a6e49c50a040023758d35886898c96c4463eedbd1bbc1ab'
Info: /Stage[main]/Main/File[/etc/crypto-policies/policies/modules/OPENSSL-SHA1.pmod]: Scheduling refresh of Class[Crypto_policies]
Info: Stage[main]: Unscheduling all events on Stage[main]
```

With contain, classes are contained and relationships work:
```
Notice: /Stage[main]/Main/File[/etc/crypto-policies/policies/modules/OPENSSL-SHA1.pmod]/ensure: defined content as '{sha256}59aa8744c5d112fc8a6e49c50a040023758d35886898c96c4463eedbd1bbc1ab'
Info: /Stage[main]/Main/File[/etc/crypto-policies/policies/modules/OPENSSL-SHA1.pmod]: Scheduling refresh of Class[Crypto_policies]
Info: Class[Crypto_policies]: Scheduling refresh of Class[Crypto_policies::Install]
Info: Class[Crypto_policies]: Scheduling refresh of Class[Crypto_policies::Config]
Info: Class[Crypto_policies::Install]: Scheduling refresh of Package[crypto-policies]
Notice: /Stage[main]/Crypto_policies::Install/Package[crypto-policies]: Triggered 'refresh' from 1 event
Info: Class[Crypto_policies::Install]: Scheduling refresh of Class[Crypto_policies::Config]
Info: Class[Crypto_policies::Config]: Scheduling refresh of Exec[update-crypto-policies]
Notice: /Stage[main]/Crypto_policies::Config/File[/etc/crypto-policies/config]/content:
Notice: /Stage[main]/Crypto_policies::Config/File[/etc/crypto-policies/config]/content: content changed '{sha256}024afa580cbbb917b9025477ee299b1bdeb6dd7019c47304dd054d9d1fd85bb7' to '{sha256}42368cb1e9aca1bef5cb03f59ebd70399b8ff1f0d131ba7d513dd2789091cea3'
Info: /Stage[main]/Crypto_policies::Config/File[/etc/crypto-policies/config]: Scheduling refresh of Exec[update-crypto-policies]
Notice: /Stage[main]/Crypto_policies::Config/Exec[update-crypto-policies]: Triggered 'refresh' from 2 events
```

An alternative would be to use `notify => Class['crypto_policies::config']`, but I consider the config class as private.
Swapping class and file declaration order would make it dependent on parse-order.